### PR TITLE
Fix error when args are numpy scalars in mxanalyzer

### DIFF
--- a/spyder_modelx/utility/typeutil.py
+++ b/spyder_modelx/utility/typeutil.py
@@ -93,5 +93,23 @@ def is_numpy_number(obj):
 
     return False
 
-
+def to_builtin(obj):
+    """ Convert a numpy scalar to its python builtin (np.int64 -> int, ...).
+        Needed because MxAnalyzer args may contain numpy scalars:
+        
+        - get_adjacent sends args as a tuple through json (TupleEncoder), and
+          numpy scalars are not JSON serializable -> tree fails to expand.
+          
+        - The double-click path sends str(args); since numpy 2.0 (NEP 51) the
+          scalar repr changed (np.int64(5) instead of 5), breaking the kernel's
+          ast.literal_eval.
+        
+        Converting to plain Python numbers keeps both paths working on any numpy version.       
+        
+    """
+    
+    if is_numpy_number(obj):
+        return obj.item()
+    return obj
+    
 

--- a/spyder_modelx/widgets/mxanalyzer/mxanalyzer_5.py
+++ b/spyder_modelx/widgets/mxanalyzer/mxanalyzer_5.py
@@ -87,6 +87,7 @@ else:
 
 
 from spyder_modelx.utility.tupleencoder import TupleEncoder
+from spyder_modelx.utility.typeutil import to_builtin
 from spyder_modelx.widgets.mxlineedit import MxPyExprLineEdit
 from spyder_modelx.widgets.mxtoolbar import MxToolBarMixin
 from spyder_modelx.widgets.mxcodeeditor import BaseCodePane
@@ -135,8 +136,9 @@ class NodeItem(object):
     def _reloadChildren(self):
         self.childItems.clear()
         sw = self.model.get_shell()
+        safe_args = tuple(to_builtin(a) for a in self.node['args'])
         nodes = sw.get_adjacent(self.node['obj']['fullname'],
-                                self.node['args'], self.adjacency)
+                                safe_args, self.adjacency)
         items = [NodeItem(node, self) for node in nodes]
         self.childItems.extend(items)
         self.isChildLoaded = True
@@ -658,7 +660,7 @@ class MxAnalyzerTree(QTreeView):
 
             item = index.internalPointer()
             obj = item.node['obj']['fullname']
-            args = str(item.node['args'])
+            args = str(tuple(to_builtin(a) for a in item.node['args']))
 
             data, _ = self.shell.get_obj_value(
                 'analyze_getval', obj, args)

--- a/spyder_modelx/widgets/mxanalyzer/mxanalyzer_6.py
+++ b/spyder_modelx/widgets/mxanalyzer/mxanalyzer_6.py
@@ -88,6 +88,7 @@ else:
 
 
 from spyder_modelx.utility.tupleencoder import TupleEncoder
+from spyder_modelx.utility.typeutil import to_builtin
 from spyder_modelx.widgets.mxlineedit import MxPyExprLineEdit
 from spyder_modelx.widgets.mxtoolbar import MxToolBarMixin
 from spyder_modelx.widgets.mxcodeeditor import BaseCodePane
@@ -144,8 +145,9 @@ class NodeItem(object):
     def _reloadChildren(self):
         self.childItems.clear()
         sw = self.model.get_shell()
+        safe_args = tuple(to_builtin(a) for a in self.node['args'])
         nodes = sw.get_adjacent(self.node['obj']['fullname'],
-                                self.node['args'], self.adjacency)
+                                safe_args, self.adjacency)
         items = [NodeItem(node, self) for node in nodes]
         self.childItems.extend(items)
         self.isChildLoaded = True
@@ -707,7 +709,7 @@ class MxAnalyzerTree(QTreeView):
 
             item = index.internalPointer()
             obj = item.node['obj']['fullname']
-            args = str(item.node['args'])
+            args = str(tuple(to_builtin(a) for a in item.node['args']))
 
             data, _ = self.shell.get_obj_value(obj, args)
 


### PR DESCRIPTION
Cells args were assumed to be Python scalars, but when a numpy array is
indexed/iterated and its elements are passed as arguments, each element is a
numpy scalar (np.int64, np.float64) rather than a Python int/float.

This caused errors in two paths:

- get_adjacent (tree expansion): args are serialized with TupleEncoder
(json), and numpy scalars are not JSON serializable → "Object of type
int64 is not JSON serializable".

- double-click value view: args are sent as str(args); since numpy 2.0
(NEP 51) the scalar repr changed (np.int64(5) instead of 5), breaking
the kernel's ast.literal_eval.

Added to_builtin() in utility/typeutil.py to convert numpy scalars to
Python builtins before sending, and applied it at both call sites in
mxanalyzer_5.py / mxanalyzer_6.py. Non-numpy args are unchanged, and no
numpy import is added (reuses is_numpy_number).